### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS=-I m4
+
 #All exported headers
 nobase_include_HEADERS = sonic/sdi_bus_api.h sonic/sdi_bus_framework.h sonic/sdi_bus.h \
                          sonic/sdi_driver_internal.h sonic/sdi_entity_info_internal.h \

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_INIT([sonic-sdi-framework], [1.0.1], [sonicproject@gmail.com])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIRS([m4])
 
 # Checks for programs.
 AC_PROG_CXX


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.